### PR TITLE
Bump org.apache.commons:commons-lang3 from 3.4 to 3.18.0 in /parent

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
         <java.minimum.version>1.8</java.minimum.version>
 
         <!-- core -->
-        <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <javax-inject.version>1</javax-inject.version>
 
         <!-- module dependencies -->


### PR DESCRIPTION
Bumps org.apache.commons:commons-lang3 from 3.4 to 3.18.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-lang3 dependency-version: 3.18.0 dependency-type: direct:development ...